### PR TITLE
Version 4.9.0.2208

### DIFF
--- a/LeoCorpLibrary.Core/Env.cs
+++ b/LeoCorpLibrary.Core/Env.cs
@@ -553,7 +553,7 @@ namespace LeoCorpLibrary.Core
 		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
 		/// <summary>
-		/// Gets the appropriate <see cref="UnitType"/> to use depending of the total sizer of the drive.
+		/// Gets the appropriate <see cref="UnitType"/> to use depending of the total size of the drive.
 		/// </summary>
 		/// <param name="driveInfo">The drive to get the unit of.</param>
 		/// <returns>A <see cref="UnitType"/> value, the appropriate unit.</returns>
@@ -584,6 +584,13 @@ namespace LeoCorpLibrary.Core
 				return UnitType.Byte;
 			}
 		}
+
+		/// <summary>
+		/// Gets if a specified drive is a CD/DVD-ROM.
+		/// </summary>
+		/// <param name="driveInfo"></param>
+		/// <returns>A <see cref="bool"/> value. <see langword="true"/> if the drive is an optical drive; <see langword="false"/> if it isn't.</returns>
+		public static bool IsDriveOpticalDrive(DriveInfo driveInfo) => driveInfo.DriveType == DriveType.CDRom;
 
 		/// <summary>
 		/// Returns <see langword="true"/> if the operating system support dark theme.

--- a/LeoCorpLibrary.Core/Env.cs
+++ b/LeoCorpLibrary.Core/Env.cs
@@ -544,13 +544,23 @@ namespace LeoCorpLibrary.Core
 		/// Gets the drive with the higest free space available.
 		/// </summary>
 		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
-		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).Last();
+		public static DriveInfo GetDriveWithHighestFreeSpace()
+		{
+			var drives = DriveInfo.GetDrives(); // Get all drives
+			drives = drives.Where(x => x.DriveType != DriveType.CDRom).ToArray(); // Remove CD-ROM
+			return drives.OrderByDescending(x => x.TotalFreeSpace).First(); // Return the drive with the highest free space
+		}
 
 		/// <summary>
 		/// Gets the drive with the lowest free space available.
 		/// </summary>
 		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
-		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
+		public static DriveInfo GetDriveWithLowestFreeSpace()
+		{
+			var drives = DriveInfo.GetDrives(); // Get all drives
+			drives = drives.Where(x => x.DriveType != DriveType.CDRom).ToArray(); // Remove CD-ROM
+			return drives.OrderBy(x => x.TotalFreeSpace).First(); // Return the drive with the lowest free space
+		}
 
 		/// <summary>
 		/// Gets the appropriate <see cref="UnitType"/> to use depending of the total size of the drive.

--- a/LeoCorpLibrary.Core/Env.cs
+++ b/LeoCorpLibrary.Core/Env.cs
@@ -544,7 +544,13 @@ namespace LeoCorpLibrary.Core
 		/// Gets the drive with the higest free space available.
 		/// </summary>
 		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
-		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
+		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).Last();
+
+		/// <summary>
+		/// Gets the drive with the lowest free space available.
+		/// </summary>
+		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
+		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
 		/// <summary>
 		/// Returns <see langword="true"/> if the operating system support dark theme.

--- a/LeoCorpLibrary.Core/Env.cs
+++ b/LeoCorpLibrary.Core/Env.cs
@@ -25,6 +25,7 @@ using LeoCorpLibrary.Core.Enums;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 #if !NET45
 using System.Runtime.InteropServices;
@@ -538,6 +539,12 @@ namespace LeoCorpLibrary.Core
 		/// <param name="driveInfo">The drive to get the occupied space percentage of.</param>
 		/// <returns>A <see cref="double"/> value, between 0 and 1.</returns>
 		public static double GetOccupiedSpacePercentage(DriveInfo driveInfo) => (driveInfo.TotalSize - driveInfo.TotalFreeSpace) / (double)driveInfo.TotalSize;
+
+		/// <summary>
+		/// Gets the drive with the higest free space available.
+		/// </summary>
+		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
+		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
 		/// <summary>
 		/// Returns <see langword="true"/> if the operating system support dark theme.

--- a/LeoCorpLibrary.Core/Env.cs
+++ b/LeoCorpLibrary.Core/Env.cs
@@ -553,6 +553,39 @@ namespace LeoCorpLibrary.Core
 		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
 		/// <summary>
+		/// Gets the appropriate <see cref="UnitType"/> to use depending of the total sizer of the drive.
+		/// </summary>
+		/// <param name="driveInfo">The drive to get the unit of.</param>
+		/// <returns>A <see cref="UnitType"/> value, the appropriate unit.</returns>
+		public static UnitType GetDriveUnitType(DriveInfo driveInfo)
+		{
+			if (driveInfo.TotalSize >= Math.Pow(1024, 5))
+			{
+				return UnitType.Petabyte;
+			}
+			if (driveInfo.TotalSize >= Math.Pow(1024, 4))
+			{
+				return UnitType.Terabyte;
+			}
+			if (driveInfo.TotalSize >= 1073741824)
+			{
+				return UnitType.Gigabyte;
+			}
+			else if (driveInfo.TotalSize >= 1048576)
+			{
+				return UnitType.Megabyte;
+			}
+			else if (driveInfo.TotalSize >= 1024)
+			{
+				return UnitType.Kilobyte;
+			}
+			else
+			{
+				return UnitType.Byte;
+			}
+		}
+
+		/// <summary>
 		/// Returns <see langword="true"/> if the operating system support dark theme.
 		/// </summary>
 		/// <remarks>

--- a/LeoCorpLibrary.Core/LeoCorpLibrary.Core.csproj
+++ b/LeoCorpLibrary.Core/LeoCorpLibrary.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net45;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-	<Version>4.9.0.2208-rc1</Version>
+	<Version>4.9.0.2208</Version>
 	<Description>A C# library with useful features for .NET Applications.</Description>
 	<Authors>Léo Corporation</Authors>
 	<Company>Léo Corporation</Company>
@@ -14,7 +14,7 @@
 	<PackageTags>Lib Library LeoCorporation C# CSharp dotnet winforms maths wpf ui leo leocorp crypt guid password generator</PackageTags>
 	<PackageIcon>icon.png</PackageIcon>
 	<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-	  <PackageReleaseNotes>Version 4.9.0.2208-rc1
+	  <PackageReleaseNotes>Version 4.9.0.2208
 - Added the possibility to get the drive with the highest free space (#345)
 - Added the possibility to get the drive with the lowest free space (#346)
 - Added the possibility to get the UnitType of a drive (#347)

--- a/LeoCorpLibrary.Core/LeoCorpLibrary.Core.csproj
+++ b/LeoCorpLibrary.Core/LeoCorpLibrary.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net45;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-	<Version>4.9.0.2208-pre1</Version>
+	<Version>4.9.0.2208-rc1</Version>
 	<Description>A C# library with useful features for .NET Applications.</Description>
 	<Authors>Léo Corporation</Authors>
 	<Company>Léo Corporation</Company>
@@ -14,9 +14,12 @@
 	<PackageTags>Lib Library LeoCorporation C# CSharp dotnet winforms maths wpf ui leo leocorp crypt guid password generator</PackageTags>
 	<PackageIcon>icon.png</PackageIcon>
 	<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-	  <PackageReleaseNotes>Version 4.9.0.2208-pre1
+	  <PackageReleaseNotes>Version 4.9.0.2208-rc1
 - Added the possibility to get the drive with the highest free space (#345)
 - Added the possibility to get the drive with the lowest free space (#346)
+- Added the possibility to get the UnitType of a drive (#347)
+- Added the possibility to get if the device has an optical disc device (#348)
+- Fixed: `GetDriveWithHighestFreeSpace()` doesn't work with optical drives…
 - Added XML Documentation </PackageReleaseNotes>
 	<AssemblyVersion>4.9.0.2208</AssemblyVersion>
 	<Copyright>© 2022</Copyright>

--- a/LeoCorpLibrary.Core/LeoCorpLibrary.Core.csproj
+++ b/LeoCorpLibrary.Core/LeoCorpLibrary.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net45;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-	<Version>4.8.0.2207</Version>
+	<Version>4.9.0.2208-pre1</Version>
 	<Description>A C# library with useful features for .NET Applications.</Description>
 	<Authors>Léo Corporation</Authors>
 	<Company>Léo Corporation</Company>
@@ -14,13 +14,11 @@
 	<PackageTags>Lib Library LeoCorporation C# CSharp dotnet winforms maths wpf ui leo leocorp crypt guid password generator</PackageTags>
 	<PackageIcon>icon.png</PackageIcon>
 	<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-	  <PackageReleaseNotes>Version 4.8.0.2207
-- Added the possibility to convert a DateTime to UnixTime (#336)
-- Added the possibility to convert Double to Int (#337)
-- Added the possibility to get the current directory of the app (#338)
-- Added the possibility to get the percentage of occupied space on a drive (#339)
-- Added XML Documentation (#340)</PackageReleaseNotes>
-	<AssemblyVersion>4.8.0.2207</AssemblyVersion>
+	  <PackageReleaseNotes>Version 4.9.0.2208-pre1
+- Added the possibility to get the drive with the highest free space (#345)
+- Added the possibility to get the drive with the lowest free space (#346)
+- Added XML Documentation </PackageReleaseNotes>
+	<AssemblyVersion>4.9.0.2208</AssemblyVersion>
 	<Copyright>© 2022</Copyright>
   </PropertyGroup>
 

--- a/LeoCorpLibrary/Env.cs
+++ b/LeoCorpLibrary/Env.cs
@@ -601,6 +601,8 @@ namespace LeoCorpLibrary
 			}
 		}
 
+		public static bool IsDriveOpticalDrive(DriveInfo driveInfo) => driveInfo.DriveType == DriveType.CDRom;
+
 		/// <summary>
 		/// Gets the current <see cref="SystemThemes"/> of the operating system (Windows only).
 		/// </summary>

--- a/LeoCorpLibrary/Env.cs
+++ b/LeoCorpLibrary/Env.cs
@@ -560,13 +560,23 @@ namespace LeoCorpLibrary
 		/// Gets the drive with the higest free space available.
 		/// </summary>
 		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
-		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).Last();
+		public static DriveInfo GetDriveWithHighestFreeSpace()
+		{
+			var drives = DriveInfo.GetDrives(); // Get all drives
+			drives = drives.Where(x => x.DriveType != DriveType.CDRom).ToArray(); // Remove CD-ROM
+			return drives.OrderByDescending(x => x.TotalFreeSpace).First(); // Return the drive with the highest free space
+		}
 
 		/// <summary>
 		/// Gets the drive with the lowest free space available.
 		/// </summary>
 		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
-		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
+		public static DriveInfo GetDriveWithLowestFreeSpace()
+		{
+			var drives = DriveInfo.GetDrives(); // Get all drives
+			drives = drives.Where(x => x.DriveType != DriveType.CDRom).ToArray(); // Remove CD-ROM
+			return drives.OrderBy(x => x.TotalFreeSpace).First(); // Return the drive with the lowest free space
+		}
 
 		/// <summary>
 		/// Gets the appropriate <see cref="UnitType"/> to use depending of the total size of the drive.
@@ -605,7 +615,7 @@ namespace LeoCorpLibrary
 		/// Gets if a specified drive is a CD/DVD-ROM.
 		/// </summary>
 		/// <param name="driveInfo"></param>
-		/// <returns></returns>
+		/// <returns>A <see cref="bool"/> value. <see langword="true"/> if the drive is an optical drive; <see langword="false"/> if it isn't.</returns>
 		public static bool IsDriveOpticalDrive(DriveInfo driveInfo) => driveInfo.DriveType == DriveType.CDRom;
 
 		/// <summary>

--- a/LeoCorpLibrary/Env.cs
+++ b/LeoCorpLibrary/Env.cs
@@ -569,7 +569,7 @@ namespace LeoCorpLibrary
 		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
 		/// <summary>
-		/// Gets the appropriate <see cref="UnitType"/> to use depending of the total sizer of the drive.
+		/// Gets the appropriate <see cref="UnitType"/> to use depending of the total size of the drive.
 		/// </summary>
 		/// <param name="driveInfo">The drive to get the unit of.</param>
 		/// <returns>A <see cref="UnitType"/> value, the appropriate unit.</returns>
@@ -601,6 +601,11 @@ namespace LeoCorpLibrary
 			}
 		}
 
+		/// <summary>
+		/// Gets if a specified drive is a CD/DVD-ROM.
+		/// </summary>
+		/// <param name="driveInfo"></param>
+		/// <returns></returns>
 		public static bool IsDriveOpticalDrive(DriveInfo driveInfo) => driveInfo.DriveType == DriveType.CDRom;
 
 		/// <summary>

--- a/LeoCorpLibrary/Env.cs
+++ b/LeoCorpLibrary/Env.cs
@@ -568,6 +568,11 @@ namespace LeoCorpLibrary
 		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
 		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
+		/// <summary>
+		/// Gets the appropriate <see cref="UnitType"/> to use depending of the total sizer of the drive.
+		/// </summary>
+		/// <param name="driveInfo">The drive to get the unit of.</param>
+		/// <returns>A <see cref="UnitType"/> value, the appropriate unit.</returns>
 		public static UnitType GetDriveUnitType(DriveInfo driveInfo)
 		{
 			if (driveInfo.TotalSize >= Math.Pow(1024, 5))

--- a/LeoCorpLibrary/Env.cs
+++ b/LeoCorpLibrary/Env.cs
@@ -556,6 +556,10 @@ namespace LeoCorpLibrary
 		/// <returns>A <see cref="double"/> value, between 0 and 1.</returns>
 		public static double GetOccupiedSpacePercentage(DriveInfo driveInfo) => (driveInfo.TotalSize - driveInfo.TotalFreeSpace) / (double)driveInfo.TotalSize;
 
+		/// <summary>
+		/// Gets the drive with the higest free space available.
+		/// </summary>
+		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
 		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
 		/// <summary>

--- a/LeoCorpLibrary/Env.cs
+++ b/LeoCorpLibrary/Env.cs
@@ -568,6 +568,34 @@ namespace LeoCorpLibrary
 		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
 		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
+		public static UnitType GetDriveUnitType(DriveInfo driveInfo)
+		{
+			if (driveInfo.TotalSize >= Math.Pow(1024, 5))
+			{
+				return UnitType.Petabyte;
+			}
+			if (driveInfo.TotalSize >= Math.Pow(1024, 4))
+			{
+				return UnitType.Terabyte;
+			}
+			if (driveInfo.TotalSize >= 1073741824)
+			{
+				return UnitType.Gigabyte;
+			}
+			else if (driveInfo.TotalSize >= 1048576)
+			{
+				return UnitType.Megabyte;
+			}
+			else if (driveInfo.TotalSize >= 1024)
+			{
+				return UnitType.Kilobyte;
+			}
+			else
+			{
+				return UnitType.Byte;
+			}
+		}
+
 		/// <summary>
 		/// Gets the current <see cref="SystemThemes"/> of the operating system (Windows only).
 		/// </summary>

--- a/LeoCorpLibrary/Env.cs
+++ b/LeoCorpLibrary/Env.cs
@@ -562,6 +562,8 @@ namespace LeoCorpLibrary
 		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
 		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
+		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).Last();
+
 		/// <summary>
 		/// Gets the current <see cref="SystemThemes"/> of the operating system (Windows only).
 		/// </summary>

--- a/LeoCorpLibrary/Env.cs
+++ b/LeoCorpLibrary/Env.cs
@@ -26,6 +26,7 @@ using Microsoft.Win32;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
@@ -554,6 +555,8 @@ namespace LeoCorpLibrary
 		/// <param name="driveInfo">The drive to get the occupied space percentage of.</param>
 		/// <returns>A <see cref="double"/> value, between 0 and 1.</returns>
 		public static double GetOccupiedSpacePercentage(DriveInfo driveInfo) => (driveInfo.TotalSize - driveInfo.TotalFreeSpace) / (double)driveInfo.TotalSize;
+
+		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
 		/// <summary>
 		/// Gets the current <see cref="SystemThemes"/> of the operating system (Windows only).

--- a/LeoCorpLibrary/Env.cs
+++ b/LeoCorpLibrary/Env.cs
@@ -560,9 +560,13 @@ namespace LeoCorpLibrary
 		/// Gets the drive with the higest free space available.
 		/// </summary>
 		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
-		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
+		public static DriveInfo GetDriveWithHighestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).Last();
 
-		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).Last();
+		/// <summary>
+		/// Gets the drive with the lowest free space available.
+		/// </summary>
+		/// <returns>A <see cref="DriveInfo"/> value, which contains the information of the drive.</returns>
+		public static DriveInfo GetDriveWithLowestFreeSpace() => DriveInfo.GetDrives().OrderBy(d => d.TotalFreeSpace).First();
 
 		/// <summary>
 		/// Gets the current <see cref="SystemThemes"/> of the operating system (Windows only).

--- a/LeoCorpLibrary/LeoCorpLibrary.csproj
+++ b/LeoCorpLibrary/LeoCorpLibrary.csproj
@@ -23,14 +23,14 @@
 	<PropertyGroup>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-		<Version>4.9.0.2208-rc1</Version>
+		<Version>4.9.0.2208</Version>
 		<Authors>Léo Corporation</Authors>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>icon.png</PackageIcon>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/Leo-Corporation/LeoCorpLibrary</RepositoryUrl>
 		<PackageTags>Lib Library LeoCorporation C# CSharp dotnet winforms maths wpf ui leo leocorp crypt guid password generator</PackageTags>
-		<PackageReleaseNotes>Version 4.9.0.2208-rc1
+		<PackageReleaseNotes>Version 4.9.0.2208
 - Added the possibility to get the drive with the highest free space (#345)
 - Added the possibility to get the drive with the lowest free space (#346)
 - Added the possibility to get the UnitType of a drive (#347)

--- a/LeoCorpLibrary/LeoCorpLibrary.csproj
+++ b/LeoCorpLibrary/LeoCorpLibrary.csproj
@@ -7,8 +7,8 @@
 		<Product>LeoCorpLibrary</Product>
 		<Description>A C# library with useful features for .NET Desktop Applications.</Description>
 		<Copyright>© 2022</Copyright>
-		<AssemblyVersion>4.8.0.2207</AssemblyVersion>
-		<FileVersion>4.8.0.2207</FileVersion>
+		<AssemblyVersion>4.9.0.2208</AssemblyVersion>
+		<FileVersion>4.9.0.2208</FileVersion>
 		<OutputPath>bin\$(Configuration)\</OutputPath>
 		<UseWindowsForms>true</UseWindowsForms>
 		<UseWPF>true</UseWPF>
@@ -23,19 +23,17 @@
 	<PropertyGroup>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-		<Version>4.8.0.2207</Version>
+		<Version>4.9.0.2208-pre1</Version>
 		<Authors>Léo Corporation</Authors>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>icon.png</PackageIcon>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/Leo-Corporation/LeoCorpLibrary</RepositoryUrl>
 		<PackageTags>Lib Library LeoCorporation C# CSharp dotnet winforms maths wpf ui leo leocorp crypt guid password generator</PackageTags>
-		<PackageReleaseNotes>Version 4.8.0.2207
-- Added the possibility to convert a DateTime to UnixTime (#336)
-- Added the possibility to convert Double to Int (#337)
-- Added the possibility to get the current directory of the app (#338)
-- Added the possibility to get the percentage of occupied space on a drive (#339)
-- Added XML Documentation (#340)</PackageReleaseNotes>
+		<PackageReleaseNotes>Version 4.9.0.2208-pre1
+- Added the possibility to get the drive with the highest free space (#345)
+- Added the possibility to get the drive with the lowest free space (#346)
+- Added XML Documentation </PackageReleaseNotes>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageProjectUrl>https://github.com/Leo-Corporation/LeoCorpLibrary/</PackageProjectUrl>
 	</PropertyGroup>

--- a/LeoCorpLibrary/LeoCorpLibrary.csproj
+++ b/LeoCorpLibrary/LeoCorpLibrary.csproj
@@ -23,16 +23,19 @@
 	<PropertyGroup>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-		<Version>4.9.0.2208-pre1</Version>
+		<Version>4.9.0.2208-rc1</Version>
 		<Authors>Léo Corporation</Authors>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>icon.png</PackageIcon>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/Leo-Corporation/LeoCorpLibrary</RepositoryUrl>
 		<PackageTags>Lib Library LeoCorporation C# CSharp dotnet winforms maths wpf ui leo leocorp crypt guid password generator</PackageTags>
-		<PackageReleaseNotes>Version 4.9.0.2208-pre1
+		<PackageReleaseNotes>Version 4.9.0.2208-rc1
 - Added the possibility to get the drive with the highest free space (#345)
 - Added the possibility to get the drive with the lowest free space (#346)
+- Added the possibility to get the UnitType of a drive (#347)
+- Added the possibility to get if the device has an optical disc device (#348)
+- Fixed: `GetDriveWithHighestFreeSpace()` doesn't work with optical drives…
 - Added XML Documentation </PackageReleaseNotes>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageProjectUrl>https://github.com/Leo-Corporation/LeoCorpLibrary/</PackageProjectUrl>


### PR DESCRIPTION
# Pull Request
<!--Put a description of the changes-->
## Changes
- Added the possibility to get the drive with the highest free space (#345)
- Added the possibility to get the drive with the lowest free space (#346)
- Added the possibility to get the UnitType of a drive (#347)
- Added the possibility to get if the device has an optical disc device (#348)
- Fixed: `GetDriveWithHighestFreeSpace()` doesn't work with optical drives (#350)
- Added XML Documentation 

<!--Put the project's name (if possible)-->
## Project
LeoCorpLibrary - Version 4.9